### PR TITLE
Add fzf configuration for Git branch completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [Unreleased]
+
+- Add fzf completion for `go **<tab>`
+
 ## [1.0.0] - 2020-10-11
 
 - Add nvm initialization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Add fzf completion for `go **<tab>`
+- Add fzf completion for `git checkout **<tab>`
+- Add fzf completion for `git switch **<tab>`
 
 ## [1.0.0] - 2020-10-11
 

--- a/zshrc
+++ b/zshrc
@@ -67,4 +67,5 @@ zstyle ':vcs_info:git:*' actionformats '(%b|%a%u%c)'
 # e.g. my-deeper/the-deepest (feature/make-better-branch|rebase) $
 PROMPT='%F{69}%2~%f %F{1}${vcs_info_msg_0_}%f$ '
 
+# Enable fzf **<tab> completion
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh

--- a/zshrc
+++ b/zshrc
@@ -76,3 +76,16 @@ _fzf_complete_go() {
 		git branch --format='%(refname:short)'
 	)
 }
+# Customize fzf **<tab> completion for certain git commands to list branches.
+# Modifies completion for 'git switch' and 'git checkout.
+_fzf_complete_git() {
+    if [[ "$@" == 'git switch '* || "$@" == 'git checkout '* ]]
+	then
+		_fzf_complete --reverse --multi -- "$@" < <(
+			git branch --format='%(refname:short)'
+		)
+	else
+		# Use default fzf completion.
+        eval "zle ${fzf_default_completion:-expand-or-complete}"
+	fi
+}

--- a/zshrc
+++ b/zshrc
@@ -69,3 +69,10 @@ PROMPT='%F{69}%2~%f %F{1}${vcs_info_msg_0_}%f$ '
 
 # Enable fzf **<tab> completion
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# Customize fzf **<tab> completion for 'go' (git alias) to list branches.
+_fzf_complete_go() {
+	_fzf_complete --reverse --multi -- "$@" < <(
+		git branch --format='%(refname:short)'
+	)
+}


### PR DESCRIPTION
Adds

- fzf completion for `go **<tab>`
- fzf completion for `git checkout **<tab>`
- fzf completion for `git switch **<tab>`

Fixes #6 