### PR TITLE
Add parent directory aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add fzf completion for `go **<tab>`
 - Add fzf completion for `git checkout **<tab>`
 - Add fzf completion for `git switch **<tab>`
+- Add parent directory aliases (e.g. `..3` for `cd ../../..`)
 
 ## [1.0.0] - 2020-10-11
 

--- a/zshrc
+++ b/zshrc
@@ -9,6 +9,15 @@ export ZPLUG_HOME=/usr/local/opt/zplug
 # Load zplug
 source $ZPLUG_HOME/init.zsh
 
+# Parent directory aliases
+alias ..="cd .."
+alias ..2="cd ../.."
+alias ..3="cd ../../.."
+alias ..4="cd ../../../.."
+alias ..5="cd ../../../../.."
+alias ..6="cd ../../../../../.."
+alias ..-="cd ../;cd -"
+
 # Git aliases
 alias ga="git add"
 alias gb="git branch"


### PR DESCRIPTION
Add parent directory aliases for:

- quickly going up a certain number of directories
(e.g. `..3` for `cd ../../..`)
- going up one directory and returning to the current directory
(i.e. `..-` for `cd ..; cd-`)

Fixes #8