### PR TITLE
Add alias 'pu' for ./vendor/bin/phpunit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add fzf completion for `git checkout **<tab>`
 - Add fzf completion for `git switch **<tab>`
 - Add parent directory aliases (e.g. `..3` for `cd ../../..`)
+- Add `pu` alias for `./vendor/bin/phpunit`
 
 ## [1.0.0] - 2020-10-11
 

--- a/zshrc
+++ b/zshrc
@@ -37,6 +37,8 @@ alias gsno="git show --name-only"
 # Add alias to source zsh configuration.
 alias sourcez="source ~/.zshrc"
 
+alias pu="./vendor/bin/phpunit"
+
 # Autoload zsh vcs_info function (-U autoload w/o substition, -z use zsh style)
 autoload -Uz vcs_info
 # Enable substitution in prompt.


### PR DESCRIPTION
When using phpunit installed via Composer, I find myself running
./vendor/bin/phpunit a lot. This alias makes this much quicker for me.

Fix #12