### PR TITLE
Remove 'gl' fallback command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Remove fallback for `gl` (previously, if `git lg` was not defined `git log --oneline --graph` was used - this is now removed)
 - Add git alias `gcanv` (for `git commit --amend --no-verify`)
 
 ## [1.1.0] - 2020-12-07

--- a/zshrc
+++ b/zshrc
@@ -30,7 +30,7 @@ alias gds="git diff --staged"
 alias gdno="git diff --name-only"
 # Use custom 'git lg' if it exists, otherwise use default git log.
 # See https://salferrarello.com/improve-git-log/
-alias gl="git lg || git log --oneline --graph"
+alias gl="git lg"
 alias go="git checkout"
 alias gs="git status"
 alias gsno="git show --name-only"


### PR DESCRIPTION
When we had the fallback in place, it prevented specifying a branch.

i.e.

```
gl mybranch
```

did not work (it always gave the git log of the current branch)

Removing the fallback command corrects this.

Resolves #16