### PR TITLE
Add fallback to gl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Remove fallback for `gl` (previously, if `git lg` was not defined `git log --oneline --graph` was used - this is now removed)
+- Modify fallback for `gl` (previously, we could not provide a specific branch (e.g. `gl develop` did NOT work))
 - Add git alias `gcanv` (for `git commit --amend --no-verify`)
 - Add git alias `gbsc` (for `git branch --show-current`)
 - Add alias `vi` to `nvim`

--- a/zshrc
+++ b/zshrc
@@ -31,11 +31,14 @@ alias gcanv="git commit --amend --no-verify"
 alias gd="git diff"
 alias gds="git diff --staged"
 alias gdno="git diff --name-only"
-# See https://salferrarello.com/improve-git-log/
-alias gl="git lg"
 alias go="git checkout"
 alias gs="git status"
 alias gsno="git show --name-only"
+
+# See https://salferrarello.com/improve-git-log/
+function gl() {
+	git lg "$@" || git log --oneline "$@"
+}
 
 # Add alias to source zsh configuration.
 alias sourcez="source ~/.zshrc"


### PR DESCRIPTION
Replace gl alias with function gl(). The function allows us to access
the command line arguments ($@) and pass them along to the commands we
actually want to run.

First we try our custom Git alias
git lg $@

and if that does not exists we fall back to default Git behavior with

git log --oneline --graph $@

Note: This still has the disadvantage that if the alias "git lg" is not
defined, we get an error message in our output (before our actual
desired output). We should address this in a future iteration but for
now this is an improvement.

See #16