### PR TITLE
Add chompeof alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove zplug ([#31](https://github.com/salcode/salcode-zsh/issues/31))
+- Add alias `chompeof` to remove the newline at the end of a given file ([#20](https://github.com/salcode/salcode-zsh/issues/20))
 
 ## [1.2.0] - 2021-12-05
 

--- a/zshrc
+++ b/zshrc
@@ -80,6 +80,9 @@ function nvmpe() {
 	nvm use $node_ver
 }
 
+# Remove Newline at End of File.
+alias chompeof="perl -pi -e 'chomp if eof'"
+
 # Add alias to source zsh configuration.
 alias sourcez="source ~/.zshrc"
 


### PR DESCRIPTION
Add chompeof alias to remove the newsline at the end of the given file.

e.g.
chompeof composer.json

See https://salferrarello.com/remove-newline-at-end-of-text-file/

Resolves #20