### PR TITLE
Render tabs as 4 spaces in less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add alias (function) `vrg` to open ripgrep results in Vim ([#36](https://github.com/salcode/salcode-zsh/issues/36))
 - Add aliases to copy pwd (`pwdcp`) and to cd to clipboard (`cdp`) ([#35](https://github.com/salcode/salcode-zsh/issues/35))
 - Add `.editorconfig` file ([#39](https://github.com/salcode/salcode-zsh/issues/39))
+- Render `tab` character as 4 spaces, when viewing a file with the `less` command ([#34](https://github.com/salcode/salcode-zsh/issues/34))
 
 ## [1.2.0] - 2021-12-05
 

--- a/zshrc
+++ b/zshrc
@@ -6,6 +6,9 @@ export NVM_DIR="$HOME/.nvm"
 # Make tty value available for GPG agent.
 export GPG_TTY=$(tty)
 
+# Render tabs as 4 spaces in less.
+export LESS="-x4R"
+
 # Parent directory aliases
 alias ..="cd .."
 alias ..2="cd ../.."


### PR DESCRIPTION
When viewing a file with the "less" command, render any tabs as 4 spaces (rather than the default 8 spaces).

This matches the 4 space rendering for tabs that I use in my code editor, making diffs viewed through "less" better match the appearance in the editor.

Resolves #34