### PR TITLE
Replace gl function with alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - BREAKING CHANGE: Replace `gl` function with an alias to `git lg` without a fallback.
-  See [2.0.0 Upgrade Path](https://github.com/salcode/salcode-zsh/wiki/Upgrade-Paths-for-Breaking-Releases#200)
+  See [2.0.0 Upgrade Path](https://github.com/salcode/salcode-zsh/wiki/Upgrade-Paths-for-Breaking-Releases#200) ([#42](https://github.com/salcode/salcode-zsh/issues/42))
 
 ## [1.3.0] - 2023-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- BREAKING CHANGE: Replace `gl` function with an alias to `git lg` without a fallback.
+  See [2.0.0 Upgrade Path](https://github.com/salcode/salcode-zsh/wiki/Upgrade-Paths-for-Breaking-Releases#200)
+
 ## [1.3.0] - 2023-09-24
 
 - Remove zplug ([#31](https://github.com/salcode/salcode-zsh/issues/31))

--- a/zshrc
+++ b/zshrc
@@ -40,19 +40,10 @@ alias go="git checkout"
 alias gs="git status"
 alias gsno="git show --name-only"
 
-# Use custom 'git lg' if it exists, otherwise use default git log.
-# See https://salferrarello.com/improve-git-log/
-function gl() {
-	# Run git lg (git alias) with command line arguments ($@)
-	# suppress any output on stderr (2>/dev/null)
-	# stop if exit code is zero (||)
-	git lg "$@" 2>/dev/null || \
-	# if exit code is 141 stop (git log often exits with 141)
-	[ $? -eq 141 ] || \
-	# the attempt to run git lg did not have exit code 0 nor 141
-	# fallback to using git log with arguments ($@)
-	git log --oneline --graph "$@"
-}
+# Note: if gl does not work, try running the following line and try again.
+# git config --global alias.lg "log --oneline --graph"
+# More details at https://salferrarello.com/improve-git-log/
+alias gl="git lg"
 
 # Read node version from package.json property .engines.node
 # and run "nvm use" with the node version.


### PR DESCRIPTION
Replace the gl function with an alias pointing gl to git lg

This maintains the current behavior if the Git alias git lg
already exists.

However, if "git lg" does not exist, "gl" no longer has a fallback of

git log --oneline --graph

and instead displays an error.

This change breaks backwards-compatibility (BC) and requires a major version bump in the next release.

This change is documented in the CHANGELOG.md and on https://github.com/salcode/salcode-zsh/wiki/Upgrade-Paths-for-Breaking-Releases#200

Resolves #42