### PR TITLE
Update setup instructions to source zshrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Modify setup instructions to source `zshrc` instead of symlinking to it ([#29](https://github.com/salcode/salcode-zsh/issues/29))
+
 ## [2.0.0] - 2023-09-24
 
 - BREAKING CHANGE: Replace `gl` function with an alias to `git lg` without a fallback.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Clone the directory in your home directory.
 git clone git@github.com:salcode/salcode-zsh.git ~/salcode-zsh.git
 ```
 
-Symlink out `zshrc` to `~/.zshrc`
+Add `source ~/salcode-zsh/zshrc` to the bottom of your `~/.zshrc` file by running the command:
 
 ```
-ln -sf ~/salcode-zsh/zshrc ~/.zshrc
+echo 'source ~/salcode-zsh/zshrc' >> ~/.zshrc
 ```
 
 ### Add fzf


### PR DESCRIPTION
Update setup instructions to source zshrc
instead of symlinking to it.

Resolves #29