### PR TITLE
Add "sayresult" alias to notify task completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Modify setup instructions to source `zshrc` instead of symlinking to it ([#29](https://github.com/salcode/salcode-zsh/issues/29))
+- Add `sayresult` alias for notification of completion (or failure) of a task (e.g. `npm install && sayresult`) ([#45](https://github.com/salcode/salcode-zsh/issues/45))
 
 ## [2.0.0] - 2023-09-24
 

--- a/zshrc
+++ b/zshrc
@@ -18,6 +18,7 @@ alias ..5="cd ../../../../.."
 alias ..6="cd ../../../../../.."
 alias ..-="cd ../;cd -"
 
+alias sayresult="say 'Task complete' || say 'Failure'"
 alias vi="nvim"
 
 # Open ripgrep results in Vim


### PR DESCRIPTION
This alias uses the macOS cli command "say" to announce "Task Complete" or "Failure" depending on the result of a command.

I find this particularly useful to use with long runninig commands.

e.g. npm install && npm run build && sayresult

See https://salferrarello.com/notify-when-command-completes/

Resolves #45