### PR TITLE
Add jqgcdiff alias to compare composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Modify setup instructions to source `zshrc` instead of symlinking to it ([#29](https://github.com/salcode/salcode-zsh/issues/29))
 - Add `sayresult` alias for notification of completion (or failure) of a task (e.g. `npm install && sayresult`) ([#45](https://github.com/salcode/salcode-zsh/issues/45))
 - Add `gd-1` alias for `git diff @{-1}` ([#44](https://github.com/salcode/salcode-zsh/issues/44))
+- Add `jqgcdiff` alias to compare the `.require` section of `composer.json` across two Git branches ([#47](https://github.com/salcode/salcode-zsh/issues/47))
 
 ## [2.0.0] - 2023-09-24
 

--- a/zshrc
+++ b/zshrc
@@ -81,6 +81,18 @@ function nvmpe() {
 	nvm use $node_ver
 }
 
+# jq git composer diff
+#
+# @param (string) Git branch to use when comparing
+#                 the .require section of composer.json
+#                 to the current Git branch.
+# See https://salferrarello.com/compare-composer-json-on-two-different-git-branches/
+function jqgcdiff() {
+	diff \
+	<(jq --sort-keys '.require' composer.json) \
+	<(git show "$1":composer.json | jq --sort-keys '.require')
+}
+
 # Remove Newline at End of File.
 alias chompeof="perl -pi -e 'chomp if eof'"
 


### PR DESCRIPTION
Add jqgcdiff alias to compare composer.json across Git branches

See https://salferrarello.com/compare-composer-json-on-two-different-git-branches/#alias

Resolves #47