### PR TITLE
Add jqcfind alias to find a composer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `sayresult` alias for notification of completion (or failure) of a task (e.g. `npm install && sayresult`) ([#45](https://github.com/salcode/salcode-zsh/issues/45))
 - Add `gd-1` alias for `git diff @{-1}` ([#44](https://github.com/salcode/salcode-zsh/issues/44))
 - Add `jqgcdiff` alias to compare the `.require` section of `composer.json` across two Git branches ([#47](https://github.com/salcode/salcode-zsh/issues/47))
+- Add `jqcfind` alias to find a full dependency name in the `.require` section of `composer.json` and copy it to the clipboard ([#48](https://github.com/salcode/salcode-zsh/issues/48))
 
 ## [2.0.0] - 2023-09-24
 

--- a/zshrc
+++ b/zshrc
@@ -81,6 +81,17 @@ function nvmpe() {
 	nvm use $node_ver
 }
 
+# Find the full package name(s) in composer.json
+# .require section and copy the name(s)
+# into the clipboard
+#
+# @param string that appears in package name(s)
+function jqcfind() {
+	jq --raw-output --arg x "$1" \
+	'.require | to_entries[] | select(.key | contains($x)) | .key' \
+	composer.json | tee >(pbcopy)
+}
+
 # jq git composer diff
 #
 # @param (string) Git branch to use when comparing


### PR DESCRIPTION
Add jqcfind alias to find a full composer dependency name in the .require section of composer.json.

e.g. On one of my projects, running

jqcfind xray

outputs

wpackagist-plugin/block-xray-attributes

and copies the string to the system clipboard on my Mac (using the pbcopy command).

See https://salferrarello.com/find-dependency-in-composer-json-with-jq/#alias

Resolves #48