### PR TITLE
Add gccd to git clone and cd into directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `gd-1` alias for `git diff @{-1}` ([#44](https://github.com/salcode/salcode-zsh/issues/44))
 - Add `jqgcdiff` alias to compare the `.require` section of `composer.json` across two Git branches ([#47](https://github.com/salcode/salcode-zsh/issues/47))
 - Add `jqcfind` alias to find a full dependency name in the `.require` section of `composer.json` and copy it to the clipboard ([#48](https://github.com/salcode/salcode-zsh/issues/48))
+- Add `gccd` alias to `git clone` and `cd` into the new directory ([#53](https://github.com/salcode/salcode-zsh/issues/53))
 
 ## [2.0.0] - 2023-09-24
 

--- a/zshrc
+++ b/zshrc
@@ -26,6 +26,13 @@ function vrg() {
 	vi -q <(rg $@ --vimgrep);
 }
 
+# git clone and cd into directory, e.g.
+# gccd git@github.com:salcode/salcode-git.git
+function gccd() {
+	git clone $1;
+	cd "$(basename $1 .git)";
+}
+
 # Git aliases
 alias ga="git add"
 alias gb="git branch"


### PR DESCRIPTION
With this alias running
gccd git@github.com:salcode/salcode-git.git

is the same as running the two commands
git clone git@github.com:salcode/salcode-git.git
cd salcode-git

Note: While our original preference was to make this a Git alias (rather than a shell alias),
it turns out Git aliases can not change directory.

See https://salferrarello.com/git-alias-can-not-change-directory/

Resolves #53