### PR TITLE
Add "git switch" aliases "gw" and "gwc"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Add `gw` and `gwc` aliases for `git switch` and `git switch --create` respectively ([#56](https://github.com/salcode/salcode-zsh/issues/56))
+
 ## [2.1.0] - 2023-12-01
 
 - Modify setup instructions to source `zshrc` instead of symlinking to it ([#29](https://github.com/salcode/salcode-zsh/issues/29))

--- a/zshrc
+++ b/zshrc
@@ -48,6 +48,8 @@ alias gdno="git diff --name-only"
 alias go="git checkout"
 alias gs="git status"
 alias gsno="git show --name-only"
+alias gw="git switch"
+alias gwc="git switch --create"
 
 # Note: if gl does not work, try running the following line and try again.
 # git config --global alias.lg "log --oneline --graph"


### PR DESCRIPTION
Add "git switch" aliases "gw" and "gwc" for
"git switch"
and
"git switch --create"
respectively.

After testing driving the more traditional "gsw" and "gswc" aliases used by others (e.g. Oh My Zsh, see
https://kapeli.com/cheat_sheets/Oh-My-Zsh_Git.docset/Contents/Resources/Documents/index#//dash_ref_Aliases/Entry/git%20switch/0 ), I decided the "s"+"w" typing was slower than I liked and have opted for the shorter "gw" instead.

Resolves #56