### PR TITLE
Add jqcwithversionfind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `gw` and `gwc` aliases for `git switch` and `git switch --create` respectively ([#56](https://github.com/salcode/salcode-zsh/issues/56))
+- Add `jqcwithversionfind`. This command is similar to `jqcfind` but returns the full package name _and_ the version constraint from `composer.json` ([#59](https://github.com/salcode/salcode-zsh/issues/59))
 
 ## [2.1.0] - 2023-12-01
 

--- a/zshrc
+++ b/zshrc
@@ -101,6 +101,17 @@ function jqcfind() {
 	composer.json | tee >(pbcopy)
 }
 
+# Find the full package name(s) and version constraint(s) in composer.json
+# .require section and copy the name(s) and version contraint(s)
+# into the clipboard
+#
+# @param string that appears in package name(s)
+function jqcwithversionfind() {
+	jq --raw-output --arg x "$1" \
+	'.require | to_entries[] | select(.key | contains($x)) | "\(.key):\(.value)"' \
+	composer.json | tee >(pbcopy)
+}
+
 # jq git composer diff
 #
 # @param (string) Git branch to use when comparing


### PR DESCRIPTION
Add "jqcwithversionfind" which is similar to "jqcfind" but returns the full package name and
the version constraint from composer.json

I'm adding this to assist me in some of the scripting I'm doing on my local machine.

Resolves #59