### PR TITLE
Add brew completions to FPATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `gw` and `gwc` aliases for `git switch` and `git switch --create` respectively ([#56](https://github.com/salcode/salcode-zsh/issues/56))
+- Add brew completions to `$FPATH` environment variable to support completions for programs installed by brew ([#62](https://github.com/salcode/salcode-zsh/issues/62))
 
 ## [2.1.0] - 2023-12-01
 

--- a/zshrc
+++ b/zshrc
@@ -153,6 +153,15 @@ zstyle ':vcs_info:*' stagedstr ' +'
 zstyle ':vcs_info:git:*' formats       '(%b%u%c)'
 zstyle ':vcs_info:git:*' actionformats '(%b|%a%u%c)'
 
+# Use brew installed program completions
+# See https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh
+if type brew &>/dev/null
+then
+	FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+	autoload -Uz compinit
+	compinit
+fi
+
 # Set Prompt to
 # - display final 2 trailing directory names
 # - Use '~' instead of '/Users/myuser' when possible


### PR DESCRIPTION
Add brew completions to FPATH to support completions for programs installed by brew

See https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh

Resolves #62