### PR TITLE
When available, use brew installed _git completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `gw` and `gwc` aliases for `git switch` and `git switch --create` respectively ([#56](https://github.com/salcode/salcode-zsh/issues/56))
 - Add brew completions to `$FPATH` environment variable to support completions for programs installed by brew ([#62](https://github.com/salcode/salcode-zsh/issues/62))
+- When the brew installed `_git` completion function is available, use that rather than the default zsh `_git` completion ([#61](https://github.com/salcode/salcode-zsh/issues/61))
 
 ## [2.1.0] - 2023-12-01
 

--- a/zshrc
+++ b/zshrc
@@ -162,6 +162,15 @@ then
 	compinit
 fi
 
+# Use Git's tab completion (_git) installed by brew instead of zsh's default
+if type brew &>/dev/null && [ -f "$(brew --prefix)/share/zsh/site-functions/_git" ];
+then
+	_git () {
+		builtin autoload -XUz "$(brew --prefix)/share/zsh/site-functions"
+	}
+fi
+
+
 # Set Prompt to
 # - display final 2 trailing directory names
 # - Use '~' instead of '/Users/myuser' when possible


### PR DESCRIPTION
When available, use brew installed _git completion over the default zsh _git completion.

Resolves #61