### PR TITLE
Add "gwf" alias to switch to branch from gbf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `openff` to open in Firefox ([#70](https://github.com/salcode/salcode-zsh/issues/70))
 - Add `gbf` to pass `git branch` output to `fzf` for selecting ([#75](https://github.com/salcode/salcode-zsh/issues/75))
+- Add `gwf` to switch to the Git branch selected with `gbf` ([#73](https://github.com/salcode/salcode-zsh/issues/73))
 
 ## [2.2.0] - 2024-12-09
 

--- a/zshrc
+++ b/zshrc
@@ -67,6 +67,7 @@ function gbf() {
 		# If the fzf selected branch starts with "*", remove the "*".
 		sed "s/^[* ]*//"
 }
+alias gwf='git switch $(gbf)'
 
 # Read node version from one of the following sources:
 # - .node-version file


### PR DESCRIPTION
Add "gwf" alias to open fzf with branches (via gbf) and on branch selection, switch to that branch.

Resolves #73