### PR TITLE
Add alias pbpaste to ensure linebreak at end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add alias `pbpasten` to paste the contents of the clipboard and ensure there is a line break at the end ([#58](https://github.com/salcode/salcode-zsh/issues/58))
 - Add `openff` to open in Firefox ([#70](https://github.com/salcode/salcode-zsh/issues/70))
 - Add `gbf` to pass `git branch` output to `fzf` for selecting ([#75](https://github.com/salcode/salcode-zsh/issues/75))
 - Add `gwf` to switch to the Git branch selected with `gbf` ([#73](https://github.com/salcode/salcode-zsh/issues/73))

--- a/zshrc
+++ b/zshrc
@@ -179,6 +179,8 @@ function jqgcdiff() {
 
 # Remove Newline at End of File.
 alias chompeof="perl -pi -e 'chomp if eof'"
+# Ensure Newline at End of Content from pbpaste.
+alias pbpasten="pbpaste | perl -pe 'END { print \"\n\" unless /\n\z/ }'"
 
 # Aliases to copy pwd and cd to clipboard
 alias pwdcp="pwd | pbcopy"

--- a/zshrc
+++ b/zshrc
@@ -183,7 +183,7 @@ function jqgcdiff() {
 # Remove Newline at End of File.
 alias chompeof="perl -pi -e 'chomp if eof'"
 # Ensure Newline at End of Content from pbpaste.
-alias pbpasten="pbpaste | perl -pe 'END { print \"\n\" unless /\n\z/ }'"
+alias pbpasten='echo "$(pbpaste)"'
 
 # Aliases to copy pwd and cd to clipboard
 alias pwdcp="pwd | pbcopy"


### PR DESCRIPTION
When copying content from a textfield in a webpage and pasting it into a file, the file is missing the ending linebreak (and this gets flagged by Git).

The pbpasten alias calls pbpaste and then pipes the output through Perl to ensure it ends with a linebreak.

pbpasten is "pbpaste" plus "n" (for new line)

Resolves #58