### PR TITLE
Move openff to script instead of alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add local `./scripts/` directory and add to `$PATH` ([#85](https://github.com/salcode/salcode-zsh/issues/85))
-- Add `openff` to open in Firefox ([#70](https://github.com/salcode/salcode-zsh/issues/70))
+- Add `openff` bash script to open in Firefox ([#70](https://github.com/salcode/salcode-zsh/issues/70),[#84](https://github.com/salcode/salcode-zsh/issues/84))
 - Add `gbf` to pass `git branch` output to `fzf` for selecting ([#75](https://github.com/salcode/salcode-zsh/issues/75))
 - Add `gwf` to switch to the Git branch selected with `gbf` ([#73](https://github.com/salcode/salcode-zsh/issues/73))
 - Add `cpbangbang` alias to copy the last command to the clipboard ([#72](https://github.com/salcode/salcode-zsh/issues/72))

--- a/scripts/openff
+++ b/scripts/openff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Open in Firefox browser.
+open -a 'Firefox' "$@"

--- a/zshrc
+++ b/zshrc
@@ -27,8 +27,6 @@ alias cpbangbang="fc -ln -1 | pbcopy"
 alias sayresult="say 'Task complete' || say 'Failure'"
 alias vi="nvim"
 
-alias openff="open -a Firefox"
-
 # Open ripgrep results in Vim
 function vrg() {
 	vi -q <(rg $@ --vimgrep);


### PR DESCRIPTION
This allows us to use openff with xargs

e.g.

echo 'https://example.com' | xargs openff

Did not work before this change
and does work now that we made this change.

Resolves #84