### PR TITLE
Add tcd to change multiple tmux panes

### DIFF
--- a/scripts/tcd
+++ b/scripts/tcd
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Bash strict mode.
+# See http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+
+function _tmux_change_dir() {
+  local _active_pane_current_path
+  _active_pane_current_path=$(tmux display-message -p '#{pane_current_path}')
+
+  for _pane in $(tmux list-panes -F '#{cursor_character}#{pane_index},#{pane_active},#{pane_current_command},#{pane_current_path}'); do
+    _cursor_character=${_pane:0:1}
+    IFS=',' read -r _pane_index _pane_active _pane_current_command _pane_current_path <<< "${_pane:1}"
+    if [[ "${_pane_current_path}" == "${_active_pane_current_path}" ]] && ([[ 'zsh' == "${_pane_current_command}" ]] || [[ 'bash' == "${_pane_current_command}" ]]); then
+      tmux send-keys -t ${_pane_index} "cd $1" Enter
+    fi
+  done
+}
+
+_tmux_change_dir "$@"


### PR DESCRIPTION
Add tcd command to change all tmux panes in the
current window that match the current directory
and are at the command prompt.

Resolves #89